### PR TITLE
CLI updates

### DIFF
--- a/base64.cli/application.cpp
+++ b/base64.cli/application.cpp
@@ -26,11 +26,8 @@ using moreland::base64::converters::decoder;
 using std::vector;
 using byte_string = std::basic_string<unsigned char>;
 
-using moreland::base64::cli::vector_of;
+using moreland::base64::cli::as_vector_of_views;
 using moreland::base64::cli::base64_run;
-using moreland::base64::cli::base64_run2;
-using moreland::base64::cli::base64_run3;
-using moreland::base64::cli::base64_run4;
 
 namespace shared = moreland::base64::shared;  // NOLINT(misc-unused-alias-decls)
 
@@ -42,7 +39,10 @@ int main(int const argc, char const* argv[])
         auto const base64_encoder = make_encoder();
         auto const base64_decoder = make_decoder();
 
-        auto const arguments = vector_of(argv, argc);
+        auto const arguments = as_vector_of_views(argv, argc);
+        if (auto const result = base64_run(arguments, base64_encoder, base64_decoder); !result) {
+            std::cout << "operation failed" << std::endl;
+        }
 
         std::string source_string = "hello world";
         byte_string source{begin(source_string), end(source_string)};

--- a/base64.cli/application.cpp
+++ b/base64.cli/application.cpp
@@ -20,23 +20,34 @@
 using moreland::base64::shared::seh_exception;
 using moreland::base64::converters::make_encoder;
 using moreland::base64::converters::make_decoder;
+using moreland::base64::converters::encoder;
+using moreland::base64::converters::decoder;
 
 using std::vector;
 using byte_string = std::basic_string<unsigned char>;
 
+using moreland::base64::cli::vector_of;
+using moreland::base64::cli::base64_run;
+using moreland::base64::cli::base64_run2;
+using moreland::base64::cli::base64_run3;
+using moreland::base64::cli::base64_run4;
+
 namespace shared = moreland::base64::shared;  // NOLINT(misc-unused-alias-decls)
 
-int main()
+int main(int const argc, char const* argv[])
 {
     try {
         seh_exception::initialize();
 
-        auto const encoder = make_encoder();
+        auto const base64_encoder = make_encoder();
+        auto const base64_decoder = make_decoder();
+
+        auto const arguments = vector_of(argv, argc);
 
         std::string source_string = "hello world";
         byte_string source{begin(source_string), end(source_string)};
 
-        auto const encoded = encoder.encode_to_string_or_empty(source);
+        auto const encoded = base64_encoder.encode_to_string_or_empty(source);
 
         char const* str = encoded.c_str(); // for debugging ease, easier to view the contents as a char*
         std::cout << str << std::endl;
@@ -44,8 +55,7 @@ int main()
         std::string encoded_source_string = "aGVsbG8gd29ybGQ=";
         source = byte_string{begin(encoded_source_string), end(encoded_source_string)};
 
-        auto const decoder = make_decoder();
-        auto const decoded = decoder.decode_to_string_or_empty(source);
+        auto const decoded = base64_decoder.decode_to_string_or_empty(source);
 
         str = decoded.c_str();
         std::cout << str << std::endl;

--- a/base64.cli/application.cpp
+++ b/base64.cli/application.cpp
@@ -31,7 +31,7 @@ using moreland::base64::cli::base64_run;
 
 namespace shared = moreland::base64::shared;  // NOLINT(misc-unused-alias-decls)
 
-int main(int const argc, char const* argv[])
+int main(int argc, char const* argv[])
 {
     try {
         seh_exception::initialize();
@@ -39,34 +39,25 @@ int main(int const argc, char const* argv[])
         auto const base64_encoder = make_encoder();
         auto const base64_decoder = make_decoder();
 
+        ++argv;
+        if (--argc < 0)
+            return -1;
+
         auto const arguments = as_vector_of_views(argv, argc);
         if (auto const result = base64_run(arguments, base64_encoder, base64_decoder); !result) {
             std::cout << "operation failed" << std::endl;
         }
 
-        std::string source_string = "hello world";
-        byte_string source{begin(source_string), end(source_string)};
-
-        auto const encoded = base64_encoder.encode_to_string_or_empty(source);
-
-        char const* str = encoded.c_str(); // for debugging ease, easier to view the contents as a char*
-        std::cout << str << std::endl;
-
-        std::string encoded_source_string = "aGVsbG8gd29ybGQ=";
-        source = byte_string{begin(encoded_source_string), end(encoded_source_string)};
-
-        auto const decoded = base64_decoder.decode_to_string_or_empty(source);
-
-        str = decoded.c_str();
-        std::cout << str << std::endl;
+        return 0;
 
     } catch (std::exception const& e) {
         std::cout << e.what() << std::endl;
+        return -1;
 
     } catch (...) {
         std::cout << "unknown error occurred" << std::endl;
+        return -1;
     }
 
-    return 0;
 }
 

--- a/base64.cli/application.cpp
+++ b/base64.cli/application.cpp
@@ -12,6 +12,7 @@
 // 
 
 #include "pch.h"
+#include "base64_app.h"
 #include "../base64.shared/seh_exception.h"
 #include "../../base64.converters/encoder.h"
 #include "../../base64.converters/decoder.h"

--- a/base64.cli/base64.cli.vcxproj
+++ b/base64.cli/base64.cli.vcxproj
@@ -103,6 +103,9 @@
     <ProjectReference Include="..\base64.shared\base64.shared.vcxproj">
       <Project>{afe4772a-fa26-4758-b8a0-9a30e45be129}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\modern_win32_api.user\win32_api.user.vcxproj">
+      <Project>{a01ba854-afd9-43db-aff4-01d6ac2e1ab6}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="application.cpp" />

--- a/base64.cli/base64.cli.vcxproj
+++ b/base64.cli/base64.cli.vcxproj
@@ -60,7 +60,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ExceptionHandling>Async</ExceptionHandling>
       <AdditionalIncludeDirectories>$(ProjectDir)include;$(SolutionDir)base64.shared\include</AdditionalIncludeDirectories>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <EnableModules>true</EnableModules>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -84,7 +84,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ExceptionHandling>Async</ExceptionHandling>
       <AdditionalIncludeDirectories>$(ProjectDir)include;$(SolutionDir)base64.shared\include</AdditionalIncludeDirectories>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <EnableModules>true</EnableModules>
     </ClCompile>
@@ -106,8 +106,10 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="application.cpp" />
+    <ClInclude Include="base64_app.h" />
     <ClInclude Include="pch.h" />
-    <ClCompile Include="pch.cpp" >
+    <ClCompile Include="base64_app.cpp" />
+    <ClCompile Include="pch.cpp">
       <DependentUpon>pch.h</DependentUpon>
     </ClCompile>
   </ItemGroup>

--- a/base64.cli/base64.cli.vcxproj.filters
+++ b/base64.cli/base64.cli.vcxproj.filters
@@ -3,8 +3,10 @@
   <ItemGroup>
     <ClCompile Include="application.cpp" />
     <ClCompile Include="pch.cpp" />
+    <ClCompile Include="base64_app.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
+    <ClInclude Include="base64_app.h" />
   </ItemGroup>
 </Project>

--- a/base64.cli/base64_app.cpp
+++ b/base64.cli/base64_app.cpp
@@ -52,7 +52,7 @@ namespace moreland::base64::cli
 
         return std::tuple<operation_type, output_type>(operation, output);
     }
-    std::vector<std::string_view> vector_of(char const* source[], std::size_t const length)
+    std::vector<std::string_view> as_vector_of_views(char const* source[], std::size_t const length)
     {
         std::vector<std::string_view> vector;
 

--- a/base64.cli/base64_app.cpp
+++ b/base64.cli/base64_app.cpp
@@ -52,4 +52,14 @@ namespace moreland::base64::cli
 
         return std::tuple<operation_type, output_type>(operation, output);
     }
+    std::vector<std::string_view> vector_of(char const* source[], std::size_t const length)
+    {
+        std::vector<std::string_view> vector;
+
+        for (std::size_t i=0; i< length; ++i) {
+            vector.emplace_back(source[i], strlen(source[i]));
+        }
+
+        return vector;
+    }
 }

--- a/base64.cli/base64_app.cpp
+++ b/base64.cli/base64_app.cpp
@@ -1,0 +1,55 @@
+//
+// Copyright © 2021 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#include "pch.h"
+#include "base64_app.h"
+
+
+namespace moreland::base64::cli
+{
+    bool string_lower_equals(std::string_view const first, std::string_view const second)
+    {
+        if (first.size() != second.size())
+            return false;
+
+        for (auto first_index = begin(first), second_index = begin(second); 
+             first_index != end(first) && second_index != end(second); 
+             ++first_index, ++second_index) {
+
+            if (tolower(*first_index) != tolower(*second_index))
+                return false;
+        }
+
+        return true;
+    }
+    std::tuple<operation_type, output_type> get_operation_and_output_from_arguments(std::span<std::string_view const> const arguments)
+    {
+        auto const arguments_length = arguments.size();
+
+        operation_type operation{operation_type::unknown};
+        if (arguments_length > 0) {
+            if (string_lower_equals(arguments[0], "decode"))
+                operation = operation_type::decode;
+            else if (string_lower_equals(arguments[0], "encode"))
+                operation = operation_type::encode;
+        }
+
+        output_type output = output_type::clipboard;
+        if (arguments_length > 2)
+            output = output_type::file_to_file;
+        else if (arguments_length > 1)
+            output = output_type::file_to_clipboard;
+
+        return std::tuple<operation_type, output_type>(operation, output);
+    }
+}

--- a/base64.cli/base64_app.h
+++ b/base64.cli/base64_app.h
@@ -118,7 +118,7 @@ namespace moreland::base64::cli
             if (converted.empty())
                 return byte_source.empty(); 
 
-            break;
+            return CLIPBOARD::set_clipboard(converted);
         }
         case output_type::file_to_clipboard:
             break;

--- a/base64.cli/base64_app.h
+++ b/base64.cli/base64_app.h
@@ -1,0 +1,102 @@
+//
+// Copyright © 2021 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#pragma once
+
+#include <span>
+#include <string>
+#include <string_view>
+#include <optional>
+#include <vector>
+
+namespace moreland::base64::cli
+{
+    using byte_string = std::basic_string<unsigned char>;
+
+    template <typename TEncoder>
+    concept Encoder = requires(TEncoder const& encoder, std::span<unsigned char const> const source)
+    {
+        { encoder.encoder(source) } -> std::convertible_to<std::optional<std::vector<unsigned char >>>;
+        { encoder.encoder_to_string_or_empty(source) } -> std::convertible_to<std::string>;
+    };
+
+    template <typename TDecoder>
+    concept Decoder = requires(TDecoder const& decoder, std::span<unsigned char const> const source)
+    {
+        { decoder.decode(source) } -> std::convertible_to<std::optional<std::vector<unsigned char >>>;
+        { decoder.decode_to_string_or_empty(source) } -> std::convertible_to<std::string>;
+    };
+
+    template <typename TClipboard>
+    concept Clipboard = requires(std::string_view const data)
+    {
+        { TClipboard::get_clipboard() } -> std::convertible_to<std::optional<std::string>>;
+        { TClipboard::set_clipboard(data) } -> std::convertible_to<bool>;
+    };
+
+    enum class operation_type
+    {
+        unknown,
+        decode,
+        encode,
+    };
+
+    enum class output_type
+    {
+        unknown,
+        clipboard,
+        file_to_clipboard,
+        file_to_file,
+    };
+
+    [[nodiscard]]
+    bool string_lower_equals(std::string_view const first, std::string_view const second);
+
+    [[nodiscard]]
+    std::tuple<operation_type, output_type> get_operation_and_output_from_arguments(std::span<std::string_view const> const arguments);
+
+    template <Encoder ENCODER, Decoder DECODER, Clipboard CLIPBOARD>
+    [[nodiscard]]
+    bool base64_run(std::span<std::string_view const> const arguments, ENCODER const& encoder, DECODER const& decoder)
+    {
+        auto [operation, output] = get_operation_and_output_from_arguments(arguments);
+
+        if (operation == operation_type::unknown) {
+            return false;
+        }
+
+        switch (output)
+        {
+        case output_type::clipboard:
+            auto const source = CLIPBOARD::get_clipboard();
+            byte_string const byte_source{begin(source), end(source)};
+
+            auto const converted = operation == operation_type::encode
+                ? encoder.encoder_to_string_or_empty(byte_source)
+                : decoder.decode_to_string_or_empty(byte_source);
+            
+            break;
+        case output_type::file_to_clipboard:
+            break;
+        case output_type::file_to_file:
+            break;
+        default:
+            return false;
+        }
+
+        return false;
+    }
+
+
+}
+

--- a/base64.cli/pch.h
+++ b/base64.cli/pch.h
@@ -15,16 +15,33 @@
 
 #define WIN32_LEAN_AND_MEAN 
 
-#include <Windows.h>
-#include <eh.h>
-#include <signal.h>
-
 #include <exception>
 #include <iomanip> 
 #include <optional>
+#include <limits>
 #include <string>
 #include <iostream>
 #include <thread>
 #include <type_traits>
 
+namespace moreland::limits
+{
+    template <std::integral T>
+    constexpr auto minimum(T first, T second)
+    {
+        return std::numeric_limits<T>::min(first, second);
+    }
+
+    template <std::integral T>
+    constexpr auto maximum(T first, T second)
+    {
+        return std::numeric_limits<T>::max(first, second);
+    }
+}
+
+#include <Windows.h>
+#include <eh.h>
+#include <csignal>
+
 #include "base64_app.h"
+

--- a/base64.cli/pch.h
+++ b/base64.cli/pch.h
@@ -26,3 +26,5 @@
 #include <iostream>
 #include <thread>
 #include <type_traits>
+
+#include "base64_app.h"

--- a/base64.converters.test/rfc4648_encoder_tests.cpp
+++ b/base64.converters.test/rfc4648_encoder_tests.cpp
@@ -18,9 +18,11 @@ using std::string_view;
 using std::vector;
 
 using moreland::base64::shared::to_string;
+using byte_string = std::basic_string<unsigned char>;
 
 namespace moreland::base64::converters::tests
 {
+
     BOOST_FIXTURE_TEST_SUITE(rfc4648_encoder_tests, rfc4648_encoder_fixture)
 
     BOOST_AUTO_TEST_CASE(encode__returns_vector__when_input_is_non_empty)
@@ -66,6 +68,16 @@ namespace moreland::base64::converters::tests
         auto const encoded = encoder().encode_to_string_or_empty(get_decoded_bytes());
 
         BOOST_CHECK_MESSAGE(encoded == ENCODED, "values do not match");
+    }
+
+    BOOST_AUTO_TEST_CASE(encode__returns_value__when_input_requires_one_padding)
+    {
+        std::string source{"hello world, from the clipboard"};
+        byte_string const source_bytes{begin(source), end(source)};
+
+        auto const actual = encoder().encode(source_bytes);
+
+        BOOST_TEST(actual.has_value());
     }
 
     BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Changes

- now processes command line args with support for clipboard to clipboard
- file to clipboard and file to file pending
- added additional test to help resolve an issue with encoded a particular string (based on length)  further tests will involved tweaking the level so we can cover all the different padding scenarios
- fixed a typo in Encoder and Decoder concept preventing the classes from matching
- moved clipboard_traits to header file so it along with Encoder and Decoder can have default values in process

## Tests
- primarily manual and existing unit tests
- found an issue manually and added a new test to cover it, currently failing but at least we can repeat the failure now