### PR TITLE
tidy up complete

### DIFF
--- a/base64.cli/application.cpp
+++ b/base64.cli/application.cpp
@@ -24,6 +24,7 @@ using moreland::base64::service::convert;
 using args_vector = std::vector<std::string_view>;
 using args_view = std::span<std::string_view const>;
 
+// ReSharper disable once CppParameterMayBeConst
 int main(int argc, char const* argv[])
 {
     try {

--- a/base64.converters.test/base64.converters.test.vcxproj
+++ b/base64.converters.test/base64.converters.test.vcxproj
@@ -25,6 +25,10 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\test\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\test\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnabled>true</VcpkgEnabled>
@@ -44,14 +48,14 @@
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="byte_producer_test_fixture.h" />
-    <ClCompile Include="byte_producer_test_fixture.cpp" >
+    <ClCompile Include="byte_producer_test_fixture.cpp">
       <DependentUpon>byte_producer_test_fixture.h</DependentUpon>
     </ClCompile>
     <ClInclude Include="decoder_test_fixture.h" />
     <ClInclude Include="encoder_test_fixture.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="test_data.h" />
-    <ClCompile Include="test_data.cpp" >
+    <ClCompile Include="test_data.cpp">
       <DependentUpon>test_data.h</DependentUpon>
     </ClCompile>
     <ClCompile Include="byte_producer_tests.cpp" />
@@ -91,6 +95,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories);$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib;$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib\manual-link</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -108,6 +113,7 @@
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories);$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib;$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib\manual-link</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/base64.converters.test/byte_producer_tests.cpp
+++ b/base64.converters.test/byte_producer_tests.cpp
@@ -22,14 +22,14 @@ namespace moreland::base64::converters::tests
     {
         auto first = producer().begin();
 
-        BOOST_CHECK(first->empty() != true);
+        BOOST_REQUIRE(first->empty() != true);
     }
 
     BOOST_AUTO_TEST_CASE(end__returns_iterator_with_empty)
     {
         auto last = producer().end();
 
-        BOOST_CHECK_THROW(static_cast<void>(last->empty()), std::out_of_range);
+        BOOST_REQUIRE_THROW(static_cast<void>(last->empty()), std::out_of_range);
     }
     BOOST_AUTO_TEST_CASE(byte_producer__supports_for_loop)
     {
@@ -40,7 +40,7 @@ namespace moreland::base64::converters::tests
             count++;
         }
 
-        BOOST_CHECK(count == production_count());
+        BOOST_REQUIRE(count == production_count());
     }
 
     BOOST_AUTO_TEST_SUITE_END()

--- a/base64.converters.test/rfc4648_decoder_tests.cpp
+++ b/base64.converters.test/rfc4648_decoder_tests.cpp
@@ -25,7 +25,7 @@ namespace moreland::base64::converters::tests
     {
         auto const decoded = decoder().convert(get_encoded_bytes());
 
-        BOOST_CHECK(decoded.has_value());
+        BOOST_REQUIRE(decoded.has_value());
     }
     BOOST_AUTO_TEST_CASE(docode__returns_expected_value__when_input_is_valid)
     {
@@ -38,8 +38,8 @@ namespace moreland::base64::converters::tests
         auto const actual_size = actual_view.size();
         auto const expected_size = expected.size();
 
-        BOOST_CHECK_MESSAGE(actual_size == expected_size, "lengths do not match");
-        BOOST_CHECK_MESSAGE(actual_view == expected, "values do not match");
+        BOOST_REQUIRE_MESSAGE(actual_size == expected_size, "lengths do not match");
+        BOOST_REQUIRE_MESSAGE(actual_view == expected, "values do not match");
     }
 
     BOOST_AUTO_TEST_SUITE_END()

--- a/base64.converters.test/rfc4648_encoder_tests.cpp
+++ b/base64.converters.test/rfc4648_encoder_tests.cpp
@@ -29,7 +29,7 @@ namespace moreland::base64::converters::tests
     {
         auto const encoded = encoder().convert(get_decoded_bytes());
 
-        BOOST_CHECK(encoded.has_value());
+        BOOST_REQUIRE(encoded.has_value());
     }
 
     BOOST_AUTO_TEST_CASE(encode__returns_expected_value__when_input_is_non_empty)
@@ -44,8 +44,8 @@ namespace moreland::base64::converters::tests
         auto const expected_size = expected.size();
 
         // semi-defy 1 assert per test, but these are just variations of the same check 
-        BOOST_CHECK_MESSAGE(actual_size == expected_size, "lengths do not match");
-        BOOST_CHECK_MESSAGE(actual_view == expected, "values do not match");
+        BOOST_REQUIRE_MESSAGE(actual_size == expected_size, "lengths do not match");
+        BOOST_REQUIRE_MESSAGE(actual_view == expected, "values do not match");
     }
 
     BOOST_AUTO_TEST_CASE(encode__return_value_matches_destination_size__when_success)
@@ -53,21 +53,21 @@ namespace moreland::base64::converters::tests
         std::vector<unsigned char> destination{};
         auto const size = encoder().convert(get_decoded_bytes(), destination);
 
-        BOOST_CHECK(size.value_or(0) == destination.size());
+        BOOST_REQUIRE(size.value_or(0) == destination.size());
     }
 
     BOOST_AUTO_TEST_CASE(encode_to_string_or_empty__returns_non_empty_string__when_input_is_non_empty)
     {
         auto const encoded = encoder().convert_to_string_or_empty(get_decoded_bytes());
 
-        BOOST_CHECK(!encoded.empty());
+        BOOST_REQUIRE(!encoded.empty());
     }
 
     BOOST_AUTO_TEST_CASE(encode_to_string_or_empty__returns_expected_value__when_input_is_non_empty)
     {
         auto const encoded = encoder().convert_to_string_or_empty(get_decoded_bytes());
 
-        BOOST_CHECK_MESSAGE(encoded == ENCODED, "values do not match");
+        BOOST_REQUIRE_MESSAGE(encoded == ENCODED, "values do not match");
     }
 
     BOOST_AUTO_TEST_CASE(encode__returns_value__when_input_requires_one_padding)

--- a/base64.service.test/base64.service.test.vcxproj
+++ b/base64.service.test/base64.service.test.vcxproj
@@ -47,7 +47,10 @@
     <VcpkgConfiguration>$(Configuration)</VcpkgConfiguration>
   </PropertyGroup>
   <ItemGroup>
+    <ClInclude Include="file_byte_producer_test_fixture.h" />
     <ClInclude Include="mock_clipboard_traits.h" />
+    <ClCompile Include="file_byte_producer_tests.cpp" />
+    <ClCompile Include="file_byte_producer_test_fixture.cpp" />
     <ClCompile Include="mock_clipboard_traits.cpp">
       <DependentUpon>mock_clipboard_traits.h</DependentUpon>
     </ClCompile>
@@ -65,7 +68,6 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="base64_app_tests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\base64.converters\base64.converters.vcxproj">
@@ -79,6 +81,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="cpp.hint" />
     <None Include="packages.config" />
     <None Include="vcpkg.json" />
     <None Include="sample.txt">
@@ -97,6 +100,7 @@
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <WarningLevel>Level4</WarningLevel>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -114,6 +118,7 @@
       <WarningLevel>Level4</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/base64.service.test/base64.service.test.vcxproj
+++ b/base64.service.test/base64.service.test.vcxproj
@@ -48,9 +48,11 @@
   </PropertyGroup>
   <ItemGroup>
     <ClInclude Include="file_byte_producer_test_fixture.h" />
+    <ClCompile Include="file_byte_producer_test_fixture.cpp" >
+      <DependentUpon>file_byte_producer_test_fixture.h</DependentUpon>
+    </ClCompile>
     <ClInclude Include="mock_clipboard_traits.h" />
     <ClCompile Include="file_byte_producer_tests.cpp" />
-    <ClCompile Include="file_byte_producer_test_fixture.cpp" />
     <ClCompile Include="mock_clipboard_traits.cpp">
       <DependentUpon>mock_clipboard_traits.h</DependentUpon>
     </ClCompile>

--- a/base64.service.test/base64.service.test.vcxproj
+++ b/base64.service.test/base64.service.test.vcxproj
@@ -24,6 +24,12 @@
   <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\test\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\test\$(Configuration)\</OutDir>
+  </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnabled>true</VcpkgEnabled>
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
@@ -75,6 +81,9 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="vcpkg.json" />
+    <None Include="sample.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemDefinitionGroup />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
@@ -92,7 +101,8 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>$(TargetDir)base64.shared.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(TargetDir)..\..\$(Configuration)\base64.shared.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories);$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib;$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib\manual-link</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -110,7 +120,8 @@
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <AdditionalDependencies>$(TargetDir)base64.shared.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(TargetDir)..\..\$(Configuration)\base64.shared.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories);$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib;$(VcpkgCurrentInstalledDir)$(VcpkgConfigSubdir)lib\manual-link</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/base64.service.test/cpp.hint
+++ b/base64.service.test/cpp.hint
@@ -1,0 +1,8 @@
+// Hint files help the Visual Studio IDE interpret Visual C++ identifiers
+// such as names of functions and macros.
+// For more information see https://go.microsoft.com/fwlink/?linkid=865984
+#define BOOST_FIXTURE_TEST_SUITE(__VA_ARGS__) BOOST_TEST_INVOKE_IF_N_ARGS( 2, BOOST_FIXTURE_TEST_SUITE_NO_DECOR, BOOST_FIXTURE_TEST_SUITE_WITH_DECOR, __VA_ARGS__)
+#define BOOST_FIXTURE_TEST_SUITE(suite_name, F) BOOST_FIXTURE_TEST_SUITE_NO_DECOR( suite_name, F )
+#define BOOST_AUTO_TEST_CASE(__VA_ARGS__) BOOST_TEST_INVOKE_IF_N_ARGS( 1, BOOST_AUTO_TEST_CASE_NO_DECOR, BOOST_AUTO_TEST_CASE_WITH_DECOR, __VA_ARGS__)
+#define BOOST_AUTO_TEST_CASE(test_name) BOOST_AUTO_TEST_CASE_NO_DECOR( test_name )
+#define BOOST_AUTO_TEST_SUITE_END() BOOST_AUTO_TU_REGISTRAR( end_suite )( 1 ); }

--- a/base64.service.test/file_byte_producer_test_fixture.cpp
+++ b/base64.service.test/file_byte_producer_test_fixture.cpp
@@ -1,0 +1,48 @@
+//
+// Copyright © 2021 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#include "pch.h"
+#include "../base64.service/file_byte_producer.h"
+#include "file_byte_producer_test_fixture.h"
+#include <fstream>
+
+namespace moreland::base64::service
+{
+    file_byte_producer file_byte_producer_test_fixture::get_producer() const
+    {
+        return file_byte_producer{test_data_filename_};
+    }
+    file_byte_producer_test_fixture::byte_string const& file_byte_producer_test_fixture::get_expected() const noexcept
+    {
+        return test_data_content_;
+    }
+    file_byte_producer_test_fixture::file_byte_producer_test_fixture()
+    {
+        using std::fstream;
+        using file_byte_stream = std::basic_fstream<unsigned char, std::char_traits<unsigned char>>;
+        using input_file_byte_stream = std::basic_ifstream<unsigned char, std::char_traits<unsigned char>>;
+        using byte_string_view = std::basic_string_view<unsigned char>;
+
+        input_file_byte_stream source{test_data_filename_};
+
+        BOOST_CHECK(source.is_open());
+
+        const int read_size = 16384;
+        auto const buffer = std::make_unique<unsigned char[]>(read_size);
+        while (source.read(buffer.get(), read_size)) {
+            // in theory this is a bad cast, but in actually it's ok due to read_size ensure gcount <= max size_type
+            byte_string_view buffer_view{buffer.get(), static_cast<byte_string_view::size_type>(source.gcount())};
+            test_data_content_.append(buffer_view);
+        }
+    }
+}

--- a/base64.service.test/file_byte_producer_test_fixture.h
+++ b/base64.service.test/file_byte_producer_test_fixture.h
@@ -1,0 +1,44 @@
+//
+// Copyright © 2020 Terry Moreland
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+// to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+// and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+
+#pragma once
+
+namespace moreland::base64::service
+{
+
+    class file_byte_producer_test_fixture
+    {
+        using byte = unsigned char;
+        using byte_vector = file_byte_producer::byte_vector;
+        using optional_byte_vector = file_byte_producer::optional_byte_vector;
+
+        char const* const test_data_filename_ = "sample.txt";
+
+        std::basic_string<byte> test_data_content_;
+    public:
+        using byte_string = std::basic_string<unsigned char>;
+
+        [[nodiscard]]
+        file_byte_producer get_producer() const;
+        [[nodiscard]]
+        byte_string const& get_expected() const noexcept;
+
+        explicit file_byte_producer_test_fixture();
+        virtual ~file_byte_producer_test_fixture() = default;
+        file_byte_producer_test_fixture(file_byte_producer_test_fixture const& ) = delete;
+        file_byte_producer_test_fixture(file_byte_producer_test_fixture&&) noexcept = delete;
+        file_byte_producer_test_fixture& operator=(file_byte_producer_test_fixture const& ) = delete;
+        file_byte_producer_test_fixture& operator=(file_byte_producer_test_fixture&&) noexcept = delete;
+    };
+
+}

--- a/base64.service.test/file_byte_producer_tests.cpp
+++ b/base64.service.test/file_byte_producer_tests.cpp
@@ -12,12 +12,22 @@
 // 
 
 #include "pch.h"
+#include "../base64.service/file_byte_producer.h"
+#include "file_byte_producer_test_fixture.h"
 
-namespace moreland::base64::cli::tests
+namespace moreland::base64::service
 {
-    BOOST_AUTO_TEST_CASE(PLACEHOLDER)
+    BOOST_FIXTURE_TEST_SUITE(file_byte_producer_tests, file_byte_producer_test_fixture)
+
+    BOOST_AUTO_TEST_CASE(chunk_or_empty__has_value__when_file_is_not_empty)
     {
-        BOOST_TEST(true);
+        auto producer = get_producer();
+
+        auto const chunk = producer.chunk_or_empty();
+
+        BOOST_REQUIRE(chunk.has_value());
     }
 
+    BOOST_AUTO_TEST_SUITE_END()
+    
 }

--- a/base64.service.test/pch.h
+++ b/base64.service.test/pch.h
@@ -41,6 +41,7 @@ namespace moreland::limits
 #include <eh.h>
 #include <csignal>
 
-#define BOOST_TEST_MODULE base64_cli_tests  // NOLINT(cppcoreguidelines-macro-usage)
+#define BOOST_TEST_MODULE base64_service_tests  // NOLINT(cppcoreguidelines-macro-usage)
 #include <boost/test/unit_test.hpp>
 
+#include "../base64.shared/std_extensions.h"

--- a/base64.service.test/sample.txt
+++ b/base64.service.test/sample.txt
@@ -1,0 +1,10 @@
+Copyright © 2021 Terry Moreland
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
+to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/base64.service.test/sample.txt
+++ b/base64.service.test/sample.txt
@@ -1,10 +1,203 @@
-Copyright © 2021 Terry Moreland
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), 
-to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# Pride and Prejudice
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+## Chapter 1
+It is a truth universally acknowledged, that a single man in possession of a good fortune, must be in want of a wife.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+However little known the feelings or views of such a man may be on his first entering a neighbourhood, this truth is so well fixed in the minds of the surrounding families, that he is considered the rightful property of some one or other of their daughters.
+
+"My dear Mr. Bennet," said his lady to him one day, "have you heard that Netherfield Park is let at last?"
+
+Mr. Bennet replied that he had not.
+
+"But it is," returned she; "for Mrs. Long has just been here, and she told me all about it."
+
+Mr. Bennet made no answer.
+
+"Do you not want to know who has taken it?" cried his wife impatiently.
+
+"You want to tell me, and I have no objection to hearing it."
+
+This was invitation enough.
+
+"Why, my dear, you must know, Mrs. Long says that Netherfield is taken by a young man of large fortune from the north of England; that he came down on Monday in a chaise and four to see the place, and was so much delighted with it, that he agreed with Mr. Morris immediately; that he is to take possession before Michaelmas, and some of his servants are to be in the house by the end of next week."
+
+"What is his name?"
+
+"Bingley."
+
+"Is he married or single?"
+
+"Oh! Single, my dear, to be sure! A single man of large fortune; four or five thousand a year. What a fine thing for our girls!"
+
+"How so? How can it affect them?"
+
+"My dear Mr. Bennet," replied his wife, "how can you be so tiresome! You must know that I am thinking of his marrying one of them."
+
+"Is that his design in settling here?"
+
+"Design! Nonsense, how can you talk so! But it is very likely that he may fall in love with one of them, and therefore you must visit him as soon as he comes."
+
+"I see no occasion for that. You and the girls may go, or you may send them by themselves, which perhaps will be still better, for as you are as handsome as any of them, Mr. Bingley may like you the best of the party."
+
+"My dear, you flatter me. I certainly have had my share of beauty, but I do not pretend to be anything extraordinary now. When a woman has five grown-up daughters, she ought to give over thinking of her own beauty."
+
+"In such cases, a woman has not often much beauty to think of."
+
+"But, my dear, you must indeed go and see Mr. Bingley when he comes into the neighbourhood."
+
+"It is more than I engage for, I assure you."
+
+"But consider your daughters. Only think what an establishment it would be for one of them. Sir William and Lady Lucas are determined to go, merely on that account, for in general, you know, they visit no newcomers. Indeed you must go, for it will be impossible for us to visit him if you do not."
+
+"You are over-scrupulous, surely. I dare say Mr. Bingley will be very glad to see you; and I will send a few lines by you to assure him of my hearty consent to his marrying whichever he chooses of the girls; though I must throw in a good word for my little Lizzy."
+
+"I desire you will do no such thing. Lizzy is not a bit better than the others; and I am sure she is not half so handsome as Jane, nor half so good-humoured as Lydia. But you are always giving her the preference."
+
+"They have none of them much to recommend them," replied he; "they are all silly and ignorant like other girls; but Lizzy has something more of quickness than her sisters."
+
+"Mr. Bennet, how can you abuse your own children in such a way? You take delight in vexing me. You have no compassion for my poor nerves."
+
+"You mistake me, my dear. I have a high respect for your nerves. They are my old friends. I have heard you mention them with consideration these last twenty years at least."
+
+"Ah, you do not know what I suffer."
+
+"But I hope you will get over it, and live to see many young men of four thousand a year come into the neighbourhood."
+
+"It will be no use to us, if twenty such should come, since you will not visit them."
+
+"Depend upon it, my dear, that when there are twenty, I will visit them all."
+
+Mr. Bennet was so odd a mixture of quick parts, sarcastic humour, reserve, and caprice, that the experience of three-and-twenty years had been insufficient to make his wife understand his character. Her mind was less difficult to develop. She was a woman of mean understanding, little information, and uncertain temper. When she was discontented, she fancied herself nervous. The business of her life was to get her daughters married; its solace was visiting and news.
+
+## Chapter 2
+
+Mr. Bennet was among the earliest of those who waited on Mr. Bingley. He had always intended to visit him, though to the last always assuring his wife that he should not go; and till the evening after the visit was paid she had no knowledge of it. It was then disclosed in the following manner. Observing his second daughter employed in trimming a hat, he suddenly addressed her with:
+
+"I hope Mr. Bingley will like it, Lizzy."
+
+"We are not in a way to know what Mr. Bingley likes," said her mother resentfully, "since we are not to visit."
+
+"But you forget, mamma," said Elizabeth, "that we shall meet him at the assemblies, and that Mrs. Long promised to introduce him."
+
+"I do not believe Mrs. Long will do any such thing. She has two nieces of her own. She is a selfish, hypocritical woman, and I have no opinion of her."
+
+"No more have I," said Mr. Bennet; "and I am glad to find that you do not depend on her serving you."
+
+Mrs. Bennet deigned not to make any reply, but, unable to contain herself, began scolding one of her daughters.
+
+"Don't keep coughing so, Kitty, for Heaven's sake! Have a little compassion on my nerves. You tear them to pieces."
+
+"Kitty has no discretion in her coughs," said her father; "she times them ill."
+
+"I do not cough for my own amusement," replied Kitty fretfully. "When is your next ball to be, Lizzy?"
+
+"To-morrow fortnight."
+
+"Aye, so it is," cried her mother, "and Mrs. Long does not come back till the day before; so it will be impossible for her to introduce him, for she will not know him herself."
+
+"Then, my dear, you may have the advantage of your friend, and introduce Mr. Bingley to her."
+
+"Impossible, Mr. Bennet, impossible, when I am not acquainted with him myself; how can you be so teasing?"
+
+"I honour your circumspection. A fortnight's acquaintance is certainly very little. One cannot know what a man really is by the end of a fortnight. But if we do not venture somebody else will; and after all, Mrs. Long and her nieces must stand their chance; and, therefore, as she will think it an act of kindness, if you decline the office, I will take it on myself."
+
+The girls stared at their father. Mrs. Bennet said only, "Nonsense, nonsense!"
+
+"What can be the meaning of that emphatic exclamation?" cried he. "Do you consider the forms of introduction, and the stress that is laid on them, as nonsense? I cannot quite agree with you there. What say you, Mary? For you are a young lady of deep reflection, I know, and read great books and make extracts."
+
+Mary wished to say something sensible, but knew not how.
+
+"While Mary is adjusting her ideas," he continued, "let us return to Mr. Bingley."
+
+"I am sick of Mr. Bingley," cried his wife.
+
+"I am sorry to hear that; but why did not you tell me that before? If I had known as much this morning I certainly would not have called on him. It is very unlucky; but as I have actually paid the visit, we cannot escape the acquaintance now."
+
+The astonishment of the ladies was just what he wished; that of Mrs. Bennet perhaps surpassing the rest; though, when the first tumult of joy was over, she began to declare that it was what she had expected all the while.
+
+"How good it was in you, my dear Mr. Bennet! But I knew I should persuade you at last. I was sure you loved your girls too well to neglect such an acquaintance. Well, how pleased I am! and it is such a good joke, too, that you should have gone this morning and never said a word about it till now."
+
+"Now, Kitty, you may cough as much as you choose," said Mr. Bennet; and, as he spoke, he left the room, fatigued with the raptures of his wife.
+
+"What an excellent father you have, girls!" said she, when the door was shut. "I do not know how you will ever make him amends for his kindness; or me, either, for that matter. At our time of life it is not so pleasant, I can tell you, to be making new acquaintances every day; but for your sakes, we would do anything. Lydia, my love, though you are the youngest, I dare say Mr. Bingley will dance with you at the next ball."
+
+"Oh!" said Lydia stoutly, "I am not afraid; for though I am the youngest, I'm the tallest."
+
+The rest of the evening was spent in conjecturing how soon he would return Mr. Bennet's visit, and determining when they should ask him to dinner.
+
+## Chapter 3
+
+Not all that Mrs. Bennet, however, with the assistance of her five daughters, could ask on the subject, was sufficient to draw from her husband any satisfactory description of Mr. Bingley. They attacked him in various ways—with barefaced questions, ingenious suppositions, and distant surmises; but he eluded the skill of them all, and they were at last obliged to accept the second-hand intelligence of their neighbour, Lady Lucas. Her report was highly favourable. Sir William had been delighted with him. He was quite young, wonderfully handsome, extremely agreeable, and, to crown the whole, he meant to be at the next assembly with a large party. Nothing could be more delightful! To be fond of dancing was a certain step towards falling in love; and very lively hopes of Mr. Bingley's heart were entertained.
+
+"If I can but see one of my daughters happily settled at Netherfield," said Mrs. Bennet to her husband, "and all the others equally well married, I shall have nothing to wish for."
+
+In a few days Mr. Bingley returned Mr. Bennet's visit, and sat about ten minutes with him in his library. He had entertained hopes of being admitted to a sight of the young ladies, of whose beauty he had heard much; but he saw only the father. The ladies were somewhat more fortunate, for they had the advantage of ascertaining from an upper window that he wore a blue coat, and rode a black horse.
+
+An invitation to dinner was soon afterwards dispatched; and already had Mrs. Bennet planned the courses that were to do credit to her housekeeping, when an answer arrived which deferred it all. Mr. Bingley was obliged to be in town the following day, and, consequently, unable to accept the honour of their invitation, etc. Mrs. Bennet was quite disconcerted. She could not imagine what business he could have in town so soon after his arrival in Hertfordshire; and she began to fear that he might be always flying about from one place to another, and never settled at Netherfield as he ought to be. Lady Lucas quieted her fears a little by starting the idea of his being gone to London only to get a large party for the ball; and a report soon followed that Mr. Bingley was to bring twelve ladies and seven gentlemen with him to the assembly. The girls grieved over such a number of ladies, but were comforted the day before the ball by hearing, that instead of twelve he brought only six with him from London—his five sisters and a cousin. And when the party entered the assembly room it consisted of only five altogether—Mr. Bingley, his two sisters, the husband of the eldest, and another young man.
+
+Mr. Bingley was good-looking and gentlemanlike; he had a pleasant countenance, and easy, unaffected manners. His sisters were fine women, with an air of decided fashion. His brother-in-law, Mr. Hurst, merely looked the gentleman; but his friend Mr. Darcy soon drew the attention of the room by his fine, tall person, handsome features, noble mien, and the report which was in general circulation within five minutes after his entrance, of his having ten thousand a year. The gentlemen pronounced him to be a fine figure of a man, the ladies declared he was much handsomer than Mr. Bingley, and he was looked at with great admiration for about half the evening, till his manners gave a disgust which turned the tide of his popularity; for he was discovered to be proud; to be above his company, and above being pleased; and not all his large estate in Derbyshire could then save him from having a most forbidding, disagreeable countenance, and being unworthy to be compared with his friend.
+
+Mr. Bingley had soon made himself acquainted with all the principal people in the room; he was lively and unreserved, danced every dance, was angry that the ball closed so early, and talked of giving one himself at Netherfield. Such amiable qualities must speak for themselves. What a contrast between him and his friend! Mr. Darcy danced only once with Mrs. Hurst and once with Miss Bingley, declined being introduced to any other lady, and spent the rest of the evening in walking about the room, speaking occasionally to one of his own party. His character was decided. He was the proudest, most disagreeable man in the world, and everybody hoped that he would never come there again. Amongst the most violent against him was Mrs. Bennet, whose dislike of his general behaviour was sharpened into particular resentment by his having slighted one of her daughters.
+
+Elizabeth Bennet had been obliged, by the scarcity of gentlemen, to sit down for two dances; and during part of that time, Mr. Darcy had been standing near enough for her to hear a conversation between him and Mr. Bingley, who came from the dance for a few minutes, to press his friend to join it.
+
+"Come, Darcy," said he, "I must have you dance. I hate to see you standing about by yourself in this stupid manner. You had much better dance."
+
+"I certainly shall not. You know how I detest it, unless I am particularly acquainted with my partner. At such an assembly as this it would be insupportable. Your sisters are engaged, and there is not another woman in the room whom it would not be a punishment to me to stand up with."
+
+"I would not be so fastidious as you are," cried Mr. Bingley, "for a kingdom! Upon my honour, I never met with so many pleasant girls in my life as I have this evening; and there are several of them you see uncommonly pretty."
+
+"You are dancing with the only handsome girl in the room," said Mr. Darcy, looking at the eldest Miss Bennet.
+
+"Oh! She is the most beautiful creature I ever beheld! But there is one of her sisters sitting down just behind you, who is very pretty, and I dare say very agreeable. Do let me ask my partner to introduce you."
+
+"Which do you mean?" and turning round he looked for a moment at Elizabeth, till catching her eye, he withdrew his own and coldly said: "She is tolerable, but not handsome enough to tempt me; I am in no humour at present to give consequence to young ladies who are slighted by other men. You had better return to your partner and enjoy her smiles, for you are wasting your time with me."
+
+Mr. Bingley followed his advice. Mr. Darcy walked off; and Elizabeth remained with no very cordial feelings toward him. She told the story, however, with great spirit among her friends; for she had a lively, playful disposition, which delighted in anything ridiculous.
+
+The evening altogether passed off pleasantly to the whole family. Mrs. Bennet had seen her eldest daughter much admired by the Netherfield party. Mr. Bingley had danced with her twice, and she had been distinguished by his sisters. Jane was as much gratified by this as her mother could be, though in a quieter way. Elizabeth felt Jane's pleasure. Mary had heard herself mentioned to Miss Bingley as the most accomplished girl in the neighbourhood; and Catherine and Lydia had been fortunate enough never to be without partners, which was all that they had yet learnt to care for at a ball. They returned, therefore, in good spirits to Longbourn, the village where they lived, and of which they were the principal inhabitants. They found Mr. Bennet still up. With a book he was regardless of time; and on the present occasion he had a good deal of curiosity as to the event of an evening which had raised such splendid expectations. He had rather hoped that his wife's views on the stranger would be disappointed; but he soon found out that he had a different story to hear.
+
+"Oh! my dear Mr. Bennet," as she entered the room, "we have had a most delightful evening, a most excellent ball. I wish you had been there. Jane was so admired, nothing could be like it. Everybody said how well she looked; and Mr. Bingley thought her quite beautiful, and danced with her twice! Only think of that, my dear; he actually danced with her twice! and she was the only creature in the room that he asked a second time. First of all, he asked Miss Lucas. I was so vexed to see him stand up with her! But, however, he did not admire her at all; indeed, nobody can, you know; and he seemed quite struck with Jane as she was going down the dance. So he inquired who she was, and got introduced, and asked her for the two next. Then the two third he danced with Miss King, and the two fourth with Maria Lucas, and the two fifth with Jane again, and the two sixth with Lizzy, and the Boulanger—"
+
+"If he had had any compassion for me," cried her husband impatiently, "he would not have danced half so much! For God's sake, say no more of his partners. Oh that he had sprained his ankle in the first dance!"
+
+"Oh! my dear, I am quite delighted with him. He is so excessively handsome! And his sisters are charming women. I never in my life saw anything more elegant than their dresses. I dare say the lace upon Mrs. Hurst's gown—"
+
+Here she was interrupted again. Mr. Bennet protested against any description of finery. She was therefore obliged to seek another branch of the subject, and related, with much bitterness of spirit and some exaggeration, the shocking rudeness of Mr. Darcy.
+
+"But I can assure you," she added, "that Lizzy does not lose much by not suiting his fancy; for he is a most disagreeable, horrid man, not at all worth pleasing. So high and so conceited that there was no enduring him! He walked here, and he walked there, fancying himself so very great! Not handsome enough to dance with! I wish you had been there, my dear, to have given him one of your set-downs. I quite detest the man."
+
+## Chapter 4
+
+When Jane and Elizabeth were alone, the former, who had been cautious in her praise of Mr. Bingley before, expressed to her sister just how very much she admired him.
+
+"He is just what a young man ought to be," said she, "sensible, good-humoured, lively; and I never saw such happy manners!—so much ease, with such perfect good breeding!"
+
+"He is also handsome," replied Elizabeth, "which a young man ought likewise to be, if he possibly can. His character is thereby complete."
+
+"I was very much flattered by his asking me to dance a second time. I did not expect such a compliment."
+
+"Did not you? I did for you. But that is one great difference between us. Compliments always take you by surprise, and me never. What could be more natural than his asking you again? He could not help seeing that you were about five times as pretty as every other woman in the room. No thanks to his gallantry for that. Well, he certainly is very agreeable, and I give you leave to like him. You have liked many a stupider person."
+
+"Dear Lizzy!"
+
+"Oh! you are a great deal too apt, you know, to like people in general. You never see a fault in anybody. All the world are good and agreeable in your eyes. I never heard you speak ill of a human being in your life."
+
+"I would not wish to be hasty in censuring anyone; but I always speak what I think."
+
+"I know you do; and it is that which makes the wonder. With your good sense, to be so honestly blind to the follies and nonsense of others! Affectation of candour is common enough—one meets with it everywhere. But to be candid without ostentation or design—to take the good of everybody's character and make it still better, and say nothing of the bad—belongs to you alone. And so you like this man's sisters, too, do you? Their manners are not equal to his."
+
+"Certainly not—at first. But they are very pleasing women when you converse with them. Miss Bingley is to live with her brother, and keep his house; and I am much mistaken if we shall not find a very charming neighbour in her."
+
+Elizabeth listened in silence, but was not convinced; their behaviour at the assembly had not been calculated to please in general; and with more quickness of observation and less pliancy of temper than her sister, and with a judgement too unassailed by any attention to herself, she was very little disposed to approve them. They were in fact very fine ladies; not deficient in good humour when they were pleased, nor in the power of making themselves agreeable when they chose it, but proud and conceited. They were rather handsome, had been educated in one of the first private seminaries in town, had a fortune of twenty thousand pounds, were in the habit of spending more than they ought, and of associating with people of rank, and were therefore in every respect entitled to think well of themselves, and meanly of others. They were of a respectable family in the north of England; a circumstance more deeply impressed on their memories than that their brother's fortune and their own had been acquired by trade.
+
+Mr. Bingley inherited property to the amount of nearly a hundred thousand pounds from his father, who had intended to purchase an estate, but did not live to do it. Mr. Bingley intended it likewise, and sometimes made choice of his county; but as he was now provided with a good house and the liberty of a manor, it was doubtful to many of those who best knew the easiness of his temper, whether he might not spend the remainder of his days at Netherfield, and leave the next generation to purchase.
+
+His sisters were anxious for his having an estate of his own; but, though he was now only established as a tenant, Miss Bingley was by no means unwilling to preside at his table—nor was Mrs. Hurst, who had married a man of more fashion than fortune, less disposed to consider his house as her home when it suited her. Mr. Bingley had not been of age two years, when he was tempted by an accidental recommendation to look at Netherfield House. He did look at it, and into it for half-an-hour—was pleased with the situation and the principal rooms, satisfied with what the owner said in its praise, and took it immediately.
+
+Between him and Darcy there was a very steady friendship, in spite of great opposition of character. Bingley was endeared to Darcy by the easiness, openness, and ductility of his temper, though no disposition could offer a greater contrast to his own, and though with his own he never appeared dissatisfied. On the strength of Darcy's regard, Bingley had the firmest reliance, and of his judgement the highest opinion. In understanding, Darcy was the superior. Bingley was by no means deficient, but Darcy was clever. He was at the same time haughty, reserved, and fastidious, and his manners, though well-bred, were not inviting. In that respect his friend had greatly the advantage. Bingley was sure of being liked wherever he appeared, Darcy was continually giving offense.
+
+The manner in which they spoke of the Meryton assembly was sufficiently characteristic. Bingley had never met with more pleasant people or prettier girls in his life; everybody had been most kind and attentive to him; there had been no formality, no stiffness; he had soon felt acquainted with all the room; and, as to Miss Bennet, he could not conceive an angel more beautiful. Darcy, on the contrary, had seen a collection of people in whom there was little beauty and no fashion, for none of whom he had felt the smallest interest, and from none received either attention or pleasure. Miss Bennet he acknowledged to be pretty, but she smiled too much.
+
+Mrs. Hurst and her sister allowed it to be so—but still they admired her and liked her, and pronounced her to be a sweet girl, and one whom they would not object to know more of. Miss Bennet was therefore established as a sweet girl, and their brother felt authorized by such commendation to think of her as he chose.
+

--- a/base64.service.test/vcpkg.json
+++ b/base64.service.test/vcpkg.json
@@ -1,7 +1,8 @@
 {
-  "name": "modern-win32-api-user-test",
+  "name": "base64-service-test",
   "version-string": "0.0.1",
   "dependencies": [
-    "boost-test"
+    "boost-test",
+    "fmt"
   ]
 }

--- a/base64.service/base64.service.vcxproj
+++ b/base64.service/base64.service.vcxproj
@@ -74,6 +74,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(VcpkgInstalledDir)$(VcpkgTriplet)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -91,6 +92,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <PrecompiledHeader>Create</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <AdditionalIncludeDirectories>$(VcpkgInstalledDir)$(VcpkgTriplet)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/base64.service/base64.service.vcxproj.filters
+++ b/base64.service/base64.service.vcxproj.filters
@@ -12,8 +12,6 @@
     <ClInclude Include="library_export.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="file_byte_consumer.cpp" />
-    <ClCompile Include="file_byte_producer.cpp" />
     <ClCompile Include="operation_type.cpp" />
     <ClCompile Include="pch.cpp" />
   </ItemGroup>

--- a/base64.service/file_byte_producer.h
+++ b/base64.service/file_byte_producer.h
@@ -27,17 +27,18 @@ namespace moreland::base64::service
     {
         const std::size_t BUFFER_SIZE = 16384;
         using file_byte_stream = std::basic_fstream<unsigned char, std::char_traits<unsigned char>>;
-        using byte_vector = std::vector<unsigned char>;
         using lock_guard = std::lock_guard<std::mutex>;
-        using optional_byte_vector = std::optional<byte_vector>;
         using bytes_view = std::span<unsigned char>;
 
         file_byte_stream source_;
         std::unique_ptr<unsigned char[]> const buffer_;
         std::mutex read_lock_;
     public:
+        using byte_vector = std::vector<unsigned char>;
+        using optional_byte_vector = std::optional<byte_vector>;
+
         [[nodiscard]]
-        std::optional<std::vector<unsigned char>> chunk_or_empty() override
+        optional_byte_vector chunk_or_empty() override
         {
             lock_guard guard{read_lock_};
 

--- a/base64.shared/maybe.h
+++ b/base64.shared/maybe.h
@@ -196,4 +196,15 @@ namespace moreland::base64::shared
 
     };
 
+    template <typename TSOURCE_RESULT, enum_t TREASON, TREASON UNKNOWN_ERROR, typename TDESTINATION_RESULT, class TMAPPER>
+    [[nodiscard]]
+    maybe<TDESTINATION_RESULT, TREASON, UNKNOWN_ERROR> map(
+        maybe<TSOURCE_RESULT, TREASON, UNKNOWN_ERROR> const& source, 
+        TMAPPER mapper)
+    {
+        return source.has_value()
+            ? maybe<TDESTINATION_RESULT, TREASON, UNKNOWN_ERROR>(mapper(source.value()))
+            : maybe<TDESTINATION_RESULT, TREASON, UNKNOWN_ERROR>{}; 
+    }
+
 }

--- a/base64.shared/std_extensions.cpp
+++ b/base64.shared/std_extensions.cpp
@@ -41,7 +41,7 @@ namespace moreland::std_extensions
             [](auto const& wide_char) {
                 return static_cast<char>(wide_char);
             });   
-        return std::string{begin(source_view), end(source_view)};
+        return destination;
 #elif __linux__
         return std::string{source.c_str()};
 #else

--- a/modern_win32_api.user.test/modern_win32_api.user.test.vcxproj
+++ b/modern_win32_api.user.test/modern_win32_api.user.test.vcxproj
@@ -24,6 +24,12 @@
   <ImportGroup Label="Shared" />
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\test\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\test\$(Configuration)\</OutDir>
+  </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnabled>true</VcpkgEnabled>
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
@@ -76,6 +82,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -94,6 +101,7 @@
       <SubSystem>Console</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
## Changes

- "simplified" convert
    - still very template heavy but have reduced the amount of code down to a fairly minimal set, now involves two lamba functions to shorted calls to hopefullly help with readability
    - essentially consistes of a for loop which filters or returns false  if any of the consume calls fail
    - second lamba function is there just to obscure the massive template parameters required to call it
 - added overload of map for maybe to base64::converters maybe.h rather than std_extensions becasue it's not a standard extension